### PR TITLE
add custom config for clickhouse and automated temp-file creation on …

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.5
+version: 0.7.6
 #
 # renovate: datasource=docker depName=clickhouse/clickhouse-server
 appVersion: 24.10.3

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -89,3 +89,14 @@ Create the backupPassword
 {{- randAlphaNum 16 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Convert a memory resource like "500Mi" to the number 500000000 (bytes)
+*/}}
+{{- define "resource-bytes" -}}
+{{- if . | hasSuffix "Mi" -}}
+{{- mul (. | trimSuffix "Mi" | int64) 1000000 -}}
+{{- else if . | hasSuffix "Gi" -}}
+{{- mul (. | trimSuffix "Gi" | int64) 1000000000 -}}
+{{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/configmap.yaml
+++ b/charts/clickhouse/templates/configmap.yaml
@@ -14,6 +14,15 @@ data:
                 <load_balancing>random</load_balancing>
                 <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
                 <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+                {{- $mem := include "resource-bytes" (default (default (dict) .Values.resources.limits ).memory .Values.resources.requests.memory) }}
+                {{- $res := int64 (div (sub (int64 $mem) 1000000000) 2) }}
+                {{- if lt $res 1000000000 }}
+                <max_bytes_before_external_group_by>0</max_bytes_before_external_group_by>
+                <max_bytes_before_external_sort>0</max_bytes_before_external_sort>
+                {{- else }}
+                <max_bytes_before_external_group_by>{{ $res }}</max_bytes_before_external_group_by>
+                <max_bytes_before_external_sort>{{ $res }}</max_bytes_before_external_sort>
+                {{- end }}
             </default>
             <reader>
                 <max_memory_usage>10000000000</max_memory_usage>
@@ -21,6 +30,15 @@ data:
                 <load_balancing>random</load_balancing>
                 <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
                 <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+                {{- $mem := include "resource-bytes" (default (default (dict) .Values.resources.limits ).memory .Values.resources.requests.memory) }}
+                {{- $res := int64 (div (sub (int64 $mem) 1000000000) 2) }}
+                {{- if lt $res 1000000000 }}
+                <max_bytes_before_external_group_by>0</max_bytes_before_external_group_by>
+                <max_bytes_before_external_sort>0</max_bytes_before_external_sort>
+                {{- else }}
+                <max_bytes_before_external_group_by>{{ $res }}</max_bytes_before_external_group_by>
+                <max_bytes_before_external_sort>{{ $res }}</max_bytes_before_external_sort>
+                {{- end }}
                 <readonly>2</readonly>
             </reader>
         </profiles>
@@ -265,4 +283,11 @@ data:
 {{ range $key, $val := .Values.cronjobs }}
   command-{{ $key }}: |-
     {{- default "exit 1" $val.command | nindent 4 }}
+{{- end }}
+
+{{- if .Values.clickhouse.customConfig }}
+  {{- range $key, $value := .Values.clickhouse.customConfig }}
+  {{ $key }}: |-
+    {{- $value | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/clickhouse/templates/statefulset.yaml
+++ b/charts/clickhouse/templates/statefulset.yaml
@@ -150,6 +150,12 @@ spec:
                 path: storage.xml
               - key: backups.xml
                 path: backups.xml
+            {{- if .Values.clickhouse.customConfig }}
+              {{- range $key, $value := .Values.clickhouse.customConfig }}
+              - key: {{ $key }}
+                path: {{ $key }}
+              {{- end }}
+            {{- end }}
         - name: logs
           emptyDir: {}
       {{- if .Values.tlsCerts.create }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -258,3 +258,11 @@ clickhouse:
     # AWS_REGION: eu-central-1
     # AWS_ACCESS_KEY_ID: XXXX
     # AWS_SECRET_ACCESS_KEY: YYYY
+
+  customConfig:
+    {}
+    # background_fetches_pool_size.xml: |-
+    #   <?xml version="1.0"?>
+    #   <clickhouse>
+    #     <background_fetches_pool_size>32</background_fetches_pool_size>
+    #   </clickhouse>


### PR DESCRIPTION
…lagre queries
The threshold formulae to set 
max_bytes_before_external_group_by
and
max_bytes_before_external_sort 
is (memory limit - 1 GB) / 2 to fit at least 2 large queries simultaneously.
if we set too low memory to Clickhouse it means non-production environment and we set this value to 0
