### PR TITLE
fix(keydb): Improve PodDisruptionBudget APIVersion detection logic

### DIFF
--- a/charts/keydb/Chart.yaml
+++ b/charts/keydb/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 #
 # renovate: datasource=docker depName=ghcr.io/sergelogvinov/keydb
 appVersion: "6.3.3"

--- a/charts/keydb/README.md
+++ b/charts/keydb/README.md
@@ -1,6 +1,6 @@
 # keydb
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.3](https://img.shields.io/badge/AppVersion-6.3.3-informational?style=flat-square)
+![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.3](https://img.shields.io/badge/AppVersion-6.3.3-informational?style=flat-square)
 
 KeyDB with TLS, backup/restore support
 
@@ -66,99 +66,99 @@ metrics:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `1` |  |
-| image.repository | string | `"ghcr.io/sergelogvinov/keydb"` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.tag | string | `""` |  |
-| kubeVersion | string | `""` |  |
-| imagePullSecrets | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| fullnameOverride | string | `""` |  |
+| affinity | object | `{}` | Affinity for pod assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
+| backup.cleanPolicy | string | `"retain FULL 7"` |  |
+| backup.enabled | bool | `false` |  |
+| backup.recovery | bool | `false` |  |
+| backup.resources.requests.cpu | string | `"100m"` |  |
+| backup.resources.requests.memory | string | `"128Mi"` |  |
+| backup.schedule | string | `"15 4 * * *"` |  |
+| backup.walg | object | `{}` |  |
+| backupCheck.affinity | object | `{}` |  |
+| backupCheck.enabled | bool | `false` |  |
+| backupCheck.nodeSelector | object | `{}` |  |
+| backupCheck.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| backupCheck.persistence.annotations | object | `{}` |  |
+| backupCheck.persistence.size | string | `"8Gi"` |  |
+| backupCheck.resources.requests.cpu | string | `"100m"` |  |
+| backupCheck.resources.requests.memory | string | `"128Mi"` |  |
+| backupCheck.schedule | string | `"15 8 * * *"` |  |
+| backupCheck.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
-| keydb.password | string | `nil` |  |
-| keydb.threads | int | `2` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"ghcr.io/sergelogvinov/keydb"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
 | keydb.activeReplica | string | `"yes"` |  |
-| keydb.multiMaster | string | `"yes"` |  |
 | keydb.maxmemory | string | `nil` |  |
 | keydb.maxmemoryPolicy | string | `"noeviction"` |  |
+| keydb.multiMaster | string | `"yes"` |  |
+| keydb.password | string | `nil` |  |
 | keydb.replBacklogSize | string | `nil` |  |
 | keydb.save[0] | string | `"900 1"` |  |
 | keydb.save[1] | string | `"120 100000"` |  |
-| tlsCerts.create | bool | `false` |  |
+| keydb.threads | int | `2` |  |
+| kubeVersion | string | `""` |  |
+| livenessProbe | object | `{}` |  |
 | loadbalancer.enabled | bool | `false` |  |
-| loadbalancer.service.labels | object | `{}` | Extra labels for load balancer service. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
-| loadbalancer.service.annotations | object | `{}` | Extra annotations for load balancer service. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| loadbalancer.service.externalTrafficPolicy | string | `"Cluster"` | Traffic policies. ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies |
-| loadbalancer.service.internalTrafficPolicy | string | `"Cluster"` |  |
-| loadbalancer.service.externalIPs | list | `[]` | Services external IPs. ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips |
-| loadbalancer.type | string | `"static"` | Type of loadbalancer. Can be dynamic or static |
-| loadbalancer.replicaCount | int | `1` |  |
-| loadbalancer.image.repository | string | `"haproxy"` |  |
 | loadbalancer.image.pullPolicy | string | `"IfNotPresent"` |  |
+| loadbalancer.image.repository | string | `"haproxy"` |  |
 | loadbalancer.image.tag | string | `"2.7.10-alpine3.18"` |  |
+| loadbalancer.livenessProbe.initialDelaySeconds | int | `10` |  |
+| loadbalancer.livenessProbe.periodSeconds | int | `60` |  |
+| loadbalancer.livenessProbe.successThreshold | int | `1` |  |
+| loadbalancer.livenessProbe.timeoutSeconds | int | `1` |  |
+| loadbalancer.podAntiAffinityPreset | string | `"soft"` |  |
+| loadbalancer.podSecurityContext.fsGroup | int | `99` |  |
+| loadbalancer.podSecurityContext.runAsGroup | int | `99` |  |
 | loadbalancer.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | loadbalancer.podSecurityContext.runAsUser | int | `99` |  |
-| loadbalancer.podSecurityContext.runAsGroup | int | `99` |  |
-| loadbalancer.podSecurityContext.fsGroup | int | `99` |  |
+| loadbalancer.readinessProbe | object | `{}` |  |
+| loadbalancer.replicaCount | int | `1` |  |
 | loadbalancer.resources.limits.cpu | string | `"500m"` |  |
 | loadbalancer.resources.limits.memory | string | `"64Mi"` |  |
 | loadbalancer.resources.requests.cpu | string | `"100m"` |  |
 | loadbalancer.resources.requests.memory | string | `"32Mi"` |  |
-| loadbalancer.livenessProbe.initialDelaySeconds | int | `10` |  |
-| loadbalancer.livenessProbe.timeoutSeconds | int | `1` |  |
-| loadbalancer.livenessProbe.successThreshold | int | `1` |  |
-| loadbalancer.livenessProbe.periodSeconds | int | `60` |  |
-| loadbalancer.readinessProbe | object | `{}` |  |
-| loadbalancer.podAntiAffinityPreset | string | `"soft"` |  |
-| backup.enabled | bool | `false` |  |
-| backup.recovery | bool | `false` |  |
-| backup.walg | object | `{}` |  |
-| backup.schedule | string | `"15 4 * * *"` |  |
-| backup.cleanPolicy | string | `"retain FULL 7"` |  |
-| backup.resources.requests.cpu | string | `"100m"` |  |
-| backup.resources.requests.memory | string | `"128Mi"` |  |
-| backupCheck.enabled | bool | `false` |  |
-| backupCheck.schedule | string | `"15 8 * * *"` |  |
-| backupCheck.resources.requests.cpu | string | `"100m"` |  |
-| backupCheck.resources.requests.memory | string | `"128Mi"` |  |
-| backupCheck.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
-| backupCheck.persistence.size | string | `"8Gi"` |  |
-| backupCheck.persistence.annotations | object | `{}` |  |
-| backupCheck.nodeSelector | object | `{}` |  |
-| backupCheck.tolerations | list | `[]` |  |
-| backupCheck.affinity | object | `{}` |  |
+| loadbalancer.service.annotations | object | `{}` | Extra annotations for load balancer service. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| loadbalancer.service.externalIPs | list | `[]` | Services external IPs. ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips |
+| loadbalancer.service.externalTrafficPolicy | string | `"Cluster"` | Traffic policies. ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies |
+| loadbalancer.service.internalTrafficPolicy | string | `"Cluster"` |  |
+| loadbalancer.service.labels | object | `{}` | Extra labels for load balancer service. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
+| loadbalancer.type | string | `"static"` | Type of loadbalancer. Can be dynamic or static |
 | metrics.enabled | bool | `false` |  |
-| metrics.image.repository | string | `"oliver006/redis_exporter"` |  |
 | metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"oliver006/redis_exporter"` |  |
 | metrics.image.tag | string | `"v1.78.0"` |  |
-| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Pods Service Account. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
-| podLabels | object | `{}` | Extra labels for pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` | Node labels for pod assignment. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"size":"10Gi"}` | Persistence parameters ref: https://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | podAnnotations | object | `{}` | Annotations for pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| podAntiAffinityPreset | string | `"soft"` | Pod Anti Affinity soft/hard |
+| podAntiAffinityPresetKey | string | `"kubernetes.io/hostname"` |  |
+| podLabels | object | `{}` | Extra labels for pod. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Pod Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
 | priorityClassName | string | `nil` | Priority Class Name ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass |
-| terminationGracePeriodSeconds | int | `30` |  |
-| livenessProbe | object | `{}` |  |
-| readinessProbe.initialDelaySeconds | int | `30` |  |
-| readinessProbe.timeoutSeconds | int | `1` |  |
 | readinessProbe.failureThreshold | int | `2` |  |
-| readinessProbe.successThreshold | int | `3` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
 | readinessProbe.periodSeconds | int | `30` |  |
-| startupProbe.initialDelaySeconds | int | `30` |  |
-| startupProbe.timeoutSeconds | int | `1` |  |
-| startupProbe.failureThreshold | int | `60` |  |
-| startupProbe.successThreshold | int | `1` |  |
-| startupProbe.periodSeconds | int | `10` |  |
+| readinessProbe.successThreshold | int | `3` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource requests and limits. ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
 | service | object | `{"annotations":{},"ipFamilies":["IPv4"],"trafficDistribution":"","type":"ClusterIP"}` | Service parameters ref: https://kubernetes.io/docs/user-guide/services/ |
-| service.type | string | `"ClusterIP"` | Service type ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
 | service.annotations | object | `{}` | Annotations for service |
 | service.ipFamilies | list | `["IPv4"]` | IP families for service possible values: IPv4, IPv6 ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | service.trafficDistribution | string | `""` | The traffic distribution for the service. possible values: PreferClose, PreferSameZone, PreferSameNode ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution |
-| resources | object | `{"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource requests and limits. ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"size":"10Gi"}` | Persistence parameters ref: https://kubernetes.io/docs/user-guide/persistent-volumes/ |
-| updateStrategy | object | `{"type":"RollingUpdate"}` | pod deployment update strategy type. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment |
-| nodeSelector | object | `{}` | Node labels for pod assignment. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| service.type | string | `"ClusterIP"` | Service type ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Pods Service Account. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
+| startupProbe.failureThreshold | int | `60` |  |
+| startupProbe.initialDelaySeconds | int | `30` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `1` |  |
+| terminationGracePeriodSeconds | int | `30` |  |
+| tlsCerts.create | bool | `false` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
-| podAntiAffinityPreset | string | `"soft"` | Pod Anti Affinity soft/hard |
-| podAntiAffinityPresetKey | string | `"kubernetes.io/hostname"` |  |
-| affinity | object | `{}` | Affinity for pod assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | pod deployment update strategy type. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment |

--- a/charts/keydb/templates/statefulset-pdb.yaml
+++ b/charts/keydb/templates/statefulset-pdb.yaml
@@ -1,8 +1,4 @@
-{{- if semverCompare ">=1.22" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: policy/v1
-{{- else -}}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ ge .Capabilities.KubeVersion.Minor "21" | ternary "policy/v1" "policy/v1beta1" }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "keydb.fullname" . }}


### PR DESCRIPTION
# Pull Request

## What?
This PR changes the way the PDB api version is dectected

## Why?
Usage of `Capabilities.KubeVersion.GitVersion` is undocumented with Helm and doesn't work for all k8s distributions.
Specifically OKD and OpenShift do not support this detection method

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [X] you update the chart version (`vi charts/${helm-chart-name}/Chart.yaml`)
- [X] you generate documentation (`make docs-${helm-chart-name}`)
- [X] you test your code (`make test PACKAGES=${helm-chart-name}`)
- [X] you PR is single commit (if not, please squash)

> See `make help` for a description of the available targets.