### PR TITLE
fix postgresql config issue in configmap

### DIFF
--- a/charts/postgresql-single/Chart.yaml
+++ b/charts/postgresql-single/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.10.1
 #
 # renovate: datasource=docker depName=ghcr.io/sergelogvinov/postgresql
 appVersion: "16.11"

--- a/charts/postgresql-single/templates/configmap.yaml
+++ b/charts/postgresql-single/templates/configmap.yaml
@@ -11,8 +11,8 @@ data:
     {{- include "postgresql-single.postgresqlConfigurationReplication" . | nindent 4 }}
 
     # auto generated, see https://pgconfigurator.cybertec.at
-    {{- include "postgresql-single.postgresqlConfigurationOptimization" . | nindent 4 }}
-    {{- include "postgresql-single.postgresqlConfigurationExtra" . | nindent 4 }}
+    {{- include "postgresql-single.postgresqlConfigurationOptimization" . | replace ":" "=" | nindent 4 }}
+    {{- include "postgresql-single.postgresqlConfigurationExtra" . | replace ":" "=" | nindent 4 }}
 
     include_if_exists '{{ .Values.persistence.mountPath }}/postgresql-local.conf'
 


### PR DESCRIPTION
when using postgresql-single helm chart in cnpg mode and here  https://github.com/sergelogvinov/helm-charts/blob/main/charts/postgresql-single/templates/configmap.yaml#L14 L15  in the CM in the postgresql.conf pushed lines like this
work_mem: 32MB
but should be
work_mem = 32MB
the half of config is ok using "=", but other is using ":"
The restore check ultimately fails.


