### PR TITLE
feat(clickhouse): add customUsersConfig for users.d/ overrides

### DIFF
--- a/charts/clickhouse/CHANGELOG.md
+++ b/charts/clickhouse/CHANGELOG.md
@@ -1,1 +1,1 @@
-- update altinity/clickhouse-backup (2.6.44 → 2.7.1)
+- add clickhouse.customUsersConfig to mount user-level config into users.d/

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.0
+version: 0.20.0
 #
 # renovate: datasource=docker depName=clickhouse/clickhouse-server
 appVersion: 26.3.10

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -172,4 +172,5 @@ metrics:
 | clickhouse.envs | object | `{}` |  |
 | clickhouse.envValueFrom | object | `{}` | Clickhouse environment variable references that will be added |
 | clickhouse.customConfig | object | `{}` |  |
+| clickhouse.customUsersConfig | object | `{}` | Clickhouse custom user-level config files mounted into `/etc/clickhouse-server/users.d/`. Use this for settings that belong to a profile/user (e.g. `async_insert_busy_timeout_ms`, `max_memory_usage`), which `customConfig` (mounted into `config.d/`) cannot override. Each key becomes a file in `users.d/`. Keys must not collide with `customConfig` keys. |
 | clickhouse.initDB | object | `{}` | Clickhouse initdb scripts |

--- a/charts/clickhouse/ci/values.yaml
+++ b/charts/clickhouse/ci/values.yaml
@@ -1,0 +1,12 @@
+clickhouse:
+  customUsersConfig:
+    async_insert_profile.xml: |-
+      <?xml version="1.0"?>
+      <clickhouse>
+        <profiles>
+          <default>
+            <async_insert_busy_timeout_ms>5000</async_insert_busy_timeout_ms>
+            <async_insert_max_data_size>10485760</async_insert_max_data_size>
+          </default>
+        </profiles>
+      </clickhouse>

--- a/charts/clickhouse/templates/configmap.yaml
+++ b/charts/clickhouse/templates/configmap.yaml
@@ -294,3 +294,10 @@ data:
     {{- $value | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.clickhouse.customUsersConfig }}
+  {{- range $key, $value := .Values.clickhouse.customUsersConfig }}
+  {{ $key }}: |-
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/statefulset.yaml
+++ b/charts/clickhouse/templates/statefulset.yaml
@@ -168,6 +168,12 @@ spec:
             items:
               - key: users.xml
                 path: users.xml
+            {{- if .Values.clickhouse.customUsersConfig }}
+              {{- range $key, $value := .Values.clickhouse.customUsersConfig }}
+              - key: {{ $key }}
+                path: {{ $key }}
+              {{- end }}
+            {{- end }}
         - name: dictionaries
           configMap:
             name: {{ include "clickhouse.fullname" . }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -445,6 +445,22 @@ clickhouse:
     #     <background_fetches_pool_size>32</background_fetches_pool_size>
     #   </clickhouse>
 
+  # -- Clickhouse custom user-level config files mounted into `/etc/clickhouse-server/users.d/`.
+  # Use this for settings that belong to a profile/user (e.g. `async_insert_busy_timeout_ms`,
+  # `max_memory_usage`), which `customConfig` (mounted into `config.d/`) cannot override.
+  # Each key becomes a file in `users.d/`. Keys must not collide with `customConfig` keys.
+  customUsersConfig: {}
+    # async_insert_profile.xml: |-
+    #   <?xml version="1.0"?>
+    #   <clickhouse>
+    #     <profiles>
+    #       <default>
+    #         <async_insert_busy_timeout_ms>5000</async_insert_busy_timeout_ms>
+    #         <async_insert_max_data_size>10485760</async_insert_max_data_size>
+    #       </default>
+    #     </profiles>
+    #   </clickhouse>
+
   # -- Clickhouse initdb scripts
   initDB: {}
     # test.sql: |-


### PR DESCRIPTION
## What

Adds a new `clickhouse.customUsersConfig` value to the **clickhouse** chart. It mirrors the existing `customConfig`, but each key is mounted as a file into `/etc/clickhouse-server/users.d/` (through the already-present `users` volume) instead of `config.d/`.

## Why

The `<profiles>` block in the generated `users.xml` is hardcoded (only derived from the pod memory), and `customConfig` only writes to `config.d/` (server-level config). As a result, **profile/user-level settings cannot be set through chart values** today.

Concrete examples that are impossible to override without this change:
- `async_insert_busy_timeout_ms` — the default (200ms) flushes async inserts very aggressively and can trigger ClickHouse "Too Many Parts" under sustained ingestion (e.g. Langfuse workloads).
- `max_memory_usage` per profile.

The only current workaround is patching the rendered ConfigMap by hand, which is overwritten on every `helm upgrade`.

## How

- `templates/configmap.yaml`: emit `customUsersConfig` keys as ConfigMap data (same pattern as `customConfig`).
- `templates/statefulset.yaml`: add those keys as `items` in the existing `users` volume, which is already mounted at `/etc/clickhouse-server/users.d`.
- `values.yaml` + `README.md`: document the new key (note: keys must not collide with `customConfig` keys, since both land in the same ConfigMap).
- `ci/values.yaml`: cover the feature with an `async_insert` profile example.

## Validation

- `helm lint charts/clickhouse` — passes (both default and with the CI values).
- `helm template` confirms the rendered file lands in the `users` volume → `users.d/`, and the default (empty `customUsersConfig`) render is unchanged (no regression).

## Backward compatibility

Fully backward compatible — `customUsersConfig` defaults to `{}`, so existing releases render identically.

Chart version bumped `0.19.0` → `0.20.0`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)