### PR TITLE
Added permissions to be able to add clickhouse instances from cicd

### DIFF
--- a/charts/rbac-common/CHANGELOG.md
+++ b/charts/rbac-common/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added permissions to be able to add clickhouse instances from cicd

--- a/charts/rbac-common/Chart.yaml
+++ b/charts/rbac-common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     url: https://github.com/sergelogvinov
 #
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 #
 #
 appVersion: "0.1.1"

--- a/charts/rbac-common/README.md
+++ b/charts/rbac-common/README.md
@@ -1,6 +1,6 @@
 # rbac-common
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
 
 Kubernetes RBAC
 

--- a/charts/rbac-common/templates/rbac-cluster-cicd.yaml
+++ b/charts/rbac-common/templates/rbac-cluster-cicd.yaml
@@ -152,4 +152,17 @@ rules:
   - delete
   - patch
   - update
+#### Clickhouse altinity
+- apiGroups:
+  - clickhouse.altinity.com
+  - clickhouse-keeper.altinity.com
+  resources:
+  - clickhouseinstallations
+  - clickhouseinstallationtemplates
+  - clickhousekeeperinstallations
+  verbs:
+  - patch
+  - update
+  - create
+  - delete
 {{- end }}


### PR DESCRIPTION
# Pull Request

## What? (description)

Added permissions for cicd role to be able to manage clickhouse instances.

## Why? (reasoning)

Because I am in the situation when I need it.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you update the chart version (`vi charts/${helm-chart-name}/Chart.yaml`)
- [x] you generate documentation (`make docs-${helm-chart-name}`)
- [x] you test your code (`make test PACKAGES=${helm-chart-name}`)
- [x] you PR is single commit (if not, please squash)

> See `make help` for a description of the available targets.
